### PR TITLE
Adds task to set storm.local.hostname parameter

### DIFF
--- a/tasks/configure-storm-nodes.yml
+++ b/tasks/configure-storm-nodes.yml
@@ -53,6 +53,11 @@
       regexp: "^(.*)nimbus.childopts:"
       line: "nimbus.childopts: {{nimbus_childopts}}"
     when: not (nimbus_childopts is undefined or nimbus_childopts is none or nimbus_childopts | trim == '')
+  - name: Set local hostname the storm node(s) should report
+    lineinfile:
+      dest: "{{storm_dir}}/conf/storm.yaml"
+      regexp: "^(.*)storm.local.hostname:"
+      line: "storm.local.hostname: {{iface_addr}}"
   - name: Set UI host for storm node(s)
     lineinfile:
       dest: "{{storm_dir}}/conf/storm.yaml"


### PR DESCRIPTION
This PR adds a task to the `dn-storm` role's playbook that sets the `storm.local.hostname` parameter in the `storm.yaml` configuration file to the IP address of the `storm_iface` that was passed into the playbook.  This resolves an issue we were seeing with `HTTP 500` errors when trying to view the Storm UI page on non-leader nodes (that error was being thrown because the hostnames that were used to register the nimbuses with Zookeeper were the hostnames for the nodes if this `storm.local.hostname` parameter is not set, and those hostnames are not resolvable in the AWS and OSP environments).