### PR TITLE
Modifications to support defining a local mirror by URL

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -81,11 +81,11 @@ optparse = OptionParser.new do |opts|
     options[:local_path] = local_path.gsub(/^=/,'')
   end
 
-  options[:yum_repo_addr] = nil
-  opts.on( '-y', '--yum-repo-host REPO_HOST', 'Local yum repository hostname/address' ) do |yum_repo_addr|
+  options[:yum_repo_url] = nil
+  opts.on( '-y', '--yum-url URL', 'Local yum repository URL' ) do |yum_repo_url|
     # while parsing, trim an '=' prefix character off the front of the string if it exists
-    # (would occur if the value was passed using an option flag like '-y=192.168.1.128')
-    options[:yum_repo_addr] = yum_repo_addr.gsub(/^=/,'')
+    # (would occur if the value was passed using an option flag like '-y=http://192.168.1.128/centos')
+    options[:yum_repo_url] = yum_repo_url.gsub(/^=/,'')
   end
 
   options[:storm_data_dir] = nil
@@ -225,10 +225,9 @@ if provisioning_command || ip_required
   end
 end
 
-# if a yum repository address was passed in, check and make sure it's a valid
-# IPv4 address
-if options[:yum_repo_addr] && !(options[:yum_repo_addr] =~ Resolv::IPv4::Regex)
-  print "ERROR; input yum repository address '#{options[:yum_repo_addr]}' is not a valid IP address\n"
+# if a yum repository address was passed in, check and make sure it's a valid URL
+if options[:yum_repo_url] && !(options[:yum_repo_url] =~ URI::regexp)
+  print "ERROR; input yum repository URL '#{options[:yum_repo_url]}' is not a valid URL\n"
   exit 6
 end
 
@@ -301,7 +300,7 @@ if storm_addr_array.size > 0
                 proxy_password: proxy_password
               },
               storm_iface: "eth1",
-              yum_repo_addr: options[:yum_repo_addr],
+              yum_repo_url: options[:yum_repo_url],
               local_path: options[:local_path],
               host_inventory: storm_addr_array,
               reset_proxy_settings: options[:reset_proxy_settings],

--- a/site.yml
+++ b/site.yml
@@ -162,8 +162,8 @@
       iface_name: "{{storm_iface}}"
     - role: setup-web-proxy
     - role: add-local-repository
-      yum_repository: "{{yum_repo_addr}}"
-      when: yum_repo_addr is defined
+      yum_repository: "{{yum_repo_url}}"
+      when: yum_repo_url is defined
     - role: install-packages
       package_list: "{{combined_package_list}}"
     - dn-storm

--- a/tasks/install-apache-storm.yml
+++ b/tasks/install-apache-storm.yml
@@ -30,6 +30,7 @@
     copy:
       src: "{{local_path}}/{{storm_url | basename}}"
       dest: "/tmp"
+      mode: 0644
   - set_fact:
       local_filename: "{{storm_url | basename}}"
   when: install_from_dir

--- a/tasks/install-apache-zookeeper.yml
+++ b/tasks/install-apache-zookeeper.yml
@@ -29,6 +29,7 @@
     copy:
       src: "{{local_path}}/{{zookeeper_url | basename}}"
       dest: "/tmp"
+      mode: 0644
   - set_fact:
       local_filename: "{{zookeeper_url | basename}}"
   when: install_from_dir


### PR DESCRIPTION
The changes in this pull request modify the existing code for adding a local repository mirror to bring it in line with the latest changes from the `common-roles/add-local-repository` role. With these changes in place, the mirror is modified by URL instead of by IP address or hostname. This should make it easier to support the directory structure that was used when building the local mirror (which may change from one local mirror to the next).

This pull request also includes a fix for a minor bug (in a couple of files), involving the permissions set when the storm (and zookeeper?) distribution files are copied over from the Ansible host.