### PR TITLE
Modifications to standardize the playbook

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -17,7 +17,7 @@
       vars:
         host_group_list:
           - { name: storm, node_list: "{{host_inventory}}" }
-          - { name: zookeeper, inventory: "{{zookeeper_inventory}}", node_list: "{{zookeeper_nodes}}" }
+          - { name: zookeeper, inventory: "{{zookeeper_inventory | default({})}}", node_list: "{{zookeeper_nodes | default([])}}" }
       when: cloud == "vagrant"
 
 # Collect some Zookeeper related facts

--- a/site.yml
+++ b/site.yml
@@ -34,21 +34,43 @@
     - vars/storm.yml
   vars:
     - combined_package_list: "{{ (default_packages|default([])) | union(storm_package_list) | union((install_packages_by_tag|default({})).storm|default([])) }}"
-  # First, determine what the "private" IP addresses of the Zookeeper ensemble are from
-  # the meta-data we gathered above in the `hostvars` hash map and the interface name
-  # that we'll be configuring Storm to listen on.  Once that's done, ensure that all of the
-  # interfaces on the Storm node(s) are up by restarting the network, then gather the facts
-  # from our Storm node(s) and deploy Storm to those nodes (configuring them appropriately)
+  # First, restart the network (unless the skip_network_restart was set)
+  # and gather some facts about our Storm node(s)
   pre_tasks:
-    - set_fact:
-        zk_nodes: "{{zookeeper_nodes | map('extract', hostvars, [('ansible_' + storm_iface), 'ipv4', 'address']) | list}}"
     - name: Ensure the network interfaces are up on our Storm node(s)
       service:
         name: network
         state: restarted
       become: true
+      when: not (skip_network_restart is defined or skip_network_restart)
     - name: Gather facts from the Storm node(s)
       setup:
+    # next, we obtain the interface names for our data_iface
+    # and api_iface (provided an interface description was provided for each)
+    - include_role:
+        name: get-iface-names
+      vars:
+        iface_descriptions: "{{iface_description_array}}"
+      when: not (iface_description_array is undefined or iface_description_array == [])
+    # and now that we know we have our data_iface identified, we can construct
+    # the list of zk_nodes (the data_iface IP addresses of our zookeeper_nodes)
+    - set_fact:
+        zk_nodes: "{{(zookeeper_nodes | default([])) | map('extract', hostvars, [('ansible_' + data_iface), 'ipv4', 'address']) | list}}"
+    # if we're provisioning a RHEL machine, then we need to ensure that
+    # it's subscribed before we can install anything (if it hasn't been
+    # registered already, of course, if that's the case then we can skip
+    # this step)
+    - block:
+      - redhat_subscription:
+          state: present
+          username: "{{rhel_username}}"
+          password: "{{rhel_password}}"
+          consumer_id: "{{rhel_consumer_id}}"
+        become: true
+        when: rhel_username is defined and rhel_password is defined and rhel_consumer_id is defined
+      when: ansible_distribution == 'RedHat'
+  # Now that we have all of the facts we need, we can run the roles that are used to
+  # deploy and configure Storm
   roles:
     - role: get-iface-addr
       iface_name: "{{storm_iface}}"


### PR DESCRIPTION
The changes in this pull request bring the `dn-storm` playbook in line with the other playbooks we are using today.  Specifically, this PR:

* adds in a default for the `zookeeper_inventory` and `zookeeper_nodes` parameters that are used when constructing host groups from a static inventory; this is critical for supporting single-node deployments (where there is no pre-existing zookeeper ensemble to pass in using these parameters).
* adds a flag that can be used to skip the 'network restart' task in the playbook; while this task still runs by default, by setting the new `skip_network_restart` to `true` in the playbook run it will be skipped (something that might be useful for deployments where we know the nodes have already been setup properly, with IP addresses assigned to all of the NICs before the playbook is run).
* adds a task to the playbook run that can be used to register a RHEL7 node; this task is only executed if values are provided for the associated `rhel_username`, `rhel_password` and `rhel_consumer_id` parameters that are needed to register the node, and if any of these parameters are not defined (or if the node being provisioned is not a RedHat node) then that task will be skipped.
* brings the `common-roles` submodule up to date so that the playbook can use the new `get-iface-names` common role to obtain the names of a set of interfaces based on an interface description array
* adds code to the playbook to support passing in that array of interface descriptions (where each interface description is a hash map consisting of a `type`, `val`, and `as_var` value, where the last value is the name of the variable that the user wants that interface's name returned as; for example (in JSON), the following hash map can be used to obtain the names of two interfaces using the CIDR value associated with each NIC (the first name being returned as the `data_iface` and the second as the `api_iface`):
    ```
    iface_description_array: [
        { as_var: 'data_iface', type: 'cidr', val: '192.168.34.0/24' },
        { as_var: 'api_iface', type: 'cidr', val: '192.168.44.0/24'  }
    ]
    ```

With these changes in place, this role now supports the same capabilities that are supported by the other roles in use today.