### PR TITLE
Documentation updates and adding support for local variables file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
 # dn-storm
-Playbooks/Roles used to deploy Apache Storm
+Playbooks/Roles used to deploy [Apache Storm](https://storm.apache.org/)
+
+# Installation
+To install Apache Storm using the `site.yml` playbook in this repository, first clone the contents of this repository to a local directory using a command like the following:
+
+```bash
+$ git clone --recursive https://github.com/Datanexus/dn-storm
+```
+
+That command will pull down the repository and it's dependencies. Currently this playbook's only dependencies are on the [common-roles](https://github.com/Datanexus/common-roles) and [common-utils](https://github.com/Datanexus/common-utils) submodules in this repository. The first provides a set of common roles that are reused across the DataNexus playbooks, while the second provides a similar set of common utilities, including a pair of dynamic inventory scripts that can be used to control deployments made using this playbook in AWS and OpenStack environments.
+
+The only other requirements for using the playbook in this repository are a relatively recent (v2.x) release of Ansible. The easiest way to obtain a recent relese if Ansible is via a `pip install`, which requires that Python and pip are both installed locally. We have performed all of our testing using a recent (2.7.x) version of Python (Python 2); your mileage may vary if you attempt to run the playbook or the attached dynamic inventory scripts under a newer (v3.x) release of Python (Python 3).
+
+# Using this role to deploy Storm
+The [site.yml](site.yml) file at the top-level of this repository supports the both single-node Storm deployments and the deployment of multi-node Storm clusters. The process of deploying Storm to these nodes will vary, depending on whether you are managing your inventory dynamically or statically (more on this topic [here](docs/Dynamic-vs-Static-Inventory.md)), whether you are performing a single-node deployment or are deploying a Storm cluster, and where you are downloading the packages and dependencies from that are needed to run Storm on those nodes.
+
+We discuss the various deployment scenarios supported by this playbook in [this document](docs/Deployment-Scenarios.md) and discuss how the [Vagrantfile](Vagrantfile) in this repository can be used to deploy Storm (both single-node deployments and multi-node clusters are supported) to a set of VMs hosted locally in VirtualBox [here](docs/Deployment-via-Vagrant.md).
+
+## Controlling the configuration
+This repository includes a default set of parameters defined in the [vars/storm.yml](vars/storm.yml) file that make it possible to perform deployments of Storm out of the box with few, if any, changes necessary. If you are not happy with the default configuration defined in that file, there are a number of ways that you can customize the configuration used for your deployment, and which method you use is entirely up to you:
+
+* You can edit the [vars/storm.yml](vars/storm.yml) file to modify the default values that are defined in that file or define additional configuration parameters
+* You can override the values defined in that file or define additional configuration parameters by passing the values for those parameters into your `ansible-playbook` run on the command-line as extra variables
+* You can setup a *local variables file* on the local filesystem of the Ansible host that contains the values for the parameters you wish to set or customize, then pass the location of that file into your `ansible-playbook` command as an extra variable
+
+We have provided a summary of the configuration parameters that can be set (using any of these three methods) during an `ansible-playbook` run [here](docs/Supported-Config-Params.md). Overall, we have found the last option to be the easiest and most flexible of those three options. This is because:
+
+* It avoids modifying files that are being tracked under version control in the main, `dn-storm` repository (the first option); making such changes will, more than likely, lead to conflicts at a later date when these files are modified in the main `dn-storm` repository in a way that is inconsistent with the values that you have set in your clone, locally.
+* It lets you maintain your preferred configuration for any given Storm deployment in the form of a configuration file, which you can easily maintain (along with the configuration files used for other deployments you have made) under version control in a separate repository
+* It provides a record of the configuration of any given deployment, which is in direct contrast to the second option (where the configuration parameters for any given deployment are passed in on the command-line as extra variables)
+
+That being said, the second option may be useful for some deployment scenarios (a one-off deployment of a local test environment, for example), so it remains a viable option for some users. Overall, we would recommend against trying to maintain your preferred cluster configuration using the values defined in the [vars/storm.yml](vars/storm.yml) file.
+
+# Assumptions
+It is assumed that this playbook will be run on a recent (systemd-based) version of RHEL or CentOS (RHEL-7.x or CentOS-7.x, for example); no support is provided for other distributions (and the `site.xml` playbook will not run successfully). Furthermore, it is assumed that you are interested in deploying a relatively recent version of Storm using this playbook (the current default is v1.0.3 but any v1.x release should do).
+
+It should also be noted that in order to execute the vagrant commands shown in [this document](docs/Deployment-via-Vagrant.md) locally, recent versions of [Vagrant](https://www.vagrantup.com/) and [VirtualBox](https://www.virtualbox.org) will have to be installed locally. While Vagrant does support management of Virtual Machines deployed via VMware Workstation and/or Fusion with the right (commercial) drivers in place, we have only tested the [Vagrantfile](Vagrantfile) in this repository under VirtualBox using recent (v1.9.x) releases of Vagrant.

--- a/docs/Deployment-Scenarios.md
+++ b/docs/Deployment-Scenarios.md
@@ -1,0 +1,157 @@
+# Example deployment scenarios
+
+There are a three basic deployment scenarios that are supported by this playbook. In the first two scenarios (shown below) we'll walk through the deployment of Storm to a single node and the deployment of a multi-node Storm cluster using a static inventory file. Finally, in the third scenario, we will show how the same multi-node Storm cluster deployment shown in the second scenario could be performed using the dynamic inventory scripts for both AWS and OpenStack instead of a static inventory file.
+
+## Scenario #1: deploying Storm to a single node
+While this is the simplest of the deployment scenarios that are supported by this playbook, it is more than likely that deployment of Storm to a single node is really only only useful for very small workloads or deployments of simple test environments. Nevertheless, we will start our discussion with this deployment scenario since it is the simplest.
+
+If we want to deploy Storm to a single node with the IP address "192.168.34.42", we would start by creating a very simple inventory file that looks something like the following:
+
+```bash
+$ cat single-node-inventory
+
+192.168.34.42 ansible_ssh_user='cloud-user' ansible_ssh_private_key_file='keys/test_node_private_key'
+
+$ 
+```
+
+Note that in this inventory file the `ansible_ssh_host` and `ansible_ssh_port` parameters will take their default values since they aren't specified for the single host entry in the inventory file. Once we've built our static inventory file, we would simply run an `ansible-playbook` command that looks something like this to perform a single-node Storm deployment to that node:
+
+```bash
+$ ansible-playbook -i single-node-inventory -e "{ host_inventory: ['192.168.34.42'] }" site.yml
+```
+
+This command will download the Apache Storm distribution from the default URL defined in the [vars/storm.yml](../vars/storm.yml) file (the main Apache download site), unpack that distribution file into the `/opt/apache-storm` directory on that host (the default value for the location to unpack the distribution into), configure the `storm` instance on that host, enable the `storm` service to start on boot, and (re)start the `storm` service. Note that for a single-node deployment, the playbook run will configure and start a bundled `zookeeper` instance, and the `storm` instance will be configured to work with that local `zookeeper` instance.
+
+## Scenario #2: deploying a multi-node Storm cluster
+If you are using this playbook to deploy a multi-node Storm cluster, then the configuration becomes a bit more complicated. The playbook assumes that if you are deploying a Storm cluster you will also want to have a multi-node Zookeeper ensemble associated with that cluster. Furthermore, to ensure that the resulting pair of clusters are relatively tolerant of the failure of a node, we highly recommend that the deployments of these two clusters (the Storm cluster and the Zookeeper ensemble) be made to separate sets of nodes. For the playbook in this repository, this separation of the Zookeeper ensemble from the Storm cluster is made by assuming that in deploying a Storm cluster we will be configuring the nodes of that cluster to work with a multi-node Zookeeper ensemble that has **already been deployed and configured separately** (and we provide a separate role and playbook, both of which are defined in the DataNexus [dn-zookeeper](https://github.com/DataNexus/dn-zookeeper) repository, that can be used to manage the process of deploying and configuring the necessary Zookeeper ensemble).
+
+So, assuming that we've already deployed a three-node Zookeeper ensemble separately and that we want to deploy a three node Storm cluster, let's walk through what the commands that we'll need to run look like. In addition, let's assume that we're going to be using a static inventory file to control our Storm deployment. The static inventory file that we will be using for this example looks like this:
+
+```bash
+$ cat test-cluster-inventory
+# example inventory file for a clustered deployment
+
+192.168.34.48 ansible_ssh_host= 192.168.34.28 ansible_ssh_port=22 ansible_ssh_user='cloud-user' ansible_ssh_private_key_file='keys/storm_cluster_private_key'
+192.168.34.49 ansible_ssh_host= 192.168.34.29 ansible_ssh_port=22 ansible_ssh_user='cloud-user' ansible_ssh_private_key_file='keys/storm_cluster_private_key'
+192.168.34.50 ansible_ssh_host= 192.168.34.30 ansible_ssh_port=22 ansible_ssh_user='cloud-user' ansible_ssh_private_key_file='keys/storm_cluster_private_key'
+
+$
+```
+
+To correctly configure our Storm cluster to talk to the Zookeeper ensemble, the playbook will need to connect to the nodes that make up the associated Zookeeper ensemble and collect information from them, and to do so we'll have to pass in the information that Ansible will need to make those connections to the playbook. We do this by passing in a separate hash of hashes (the `zookeeper_inventory` for the deployment) that maps the same parameters shown above to each of the members of our Zookeeper ensemble. For the purposes of this example, let's assume that our `zookeeper_inventory` hash map looks something like this:
+
+```json
+    {
+      '192.168.34.18': { ansible_ssh_host: '192.168.34.18', ansible_ssh_port: 22, ansible_ssh_user: 'cloud-user', ansible_ssh_private_key_file: 'keys/zk_cluster_private_key'},
+      '192.168.34.19': { ansible_ssh_host: '192.168.34.19', ansible_ssh_port: 22, ansible_ssh_user: 'cloud-user', ansible_ssh_private_key_file: 'keys/zk_cluster_private_key'},
+      '192.168.34.20': { ansible_ssh_host: '192.168.34.20', ansible_ssh_port: 22, ansible_ssh_user: 'cloud-user', ansible_ssh_private_key_file: 'keys/zk_cluster_private_key'},
+    }
+```
+
+To deploy Storm to the three nodes in our static inventory file, we'd run a command that looks something like this:
+
+```bash
+$ ansible-playbook -i test-cluster-inventory -e "{ \
+      host_inventory: ['192.168.34.48', '192.168.34.49', '192.168.34.50'], \
+      cloud: vagrant, data_iface: eth0, api_iface: eth1, \
+      zookeeper_nodes: ['192.168.34.18', '192.168.34.19', '192.168.34.20'], \
+      zookeeper_inventory: {
+          '192.168.34.18': { ansible_ssh_host: '192.168.34.18', ansible_ssh_port: 22, \
+              ansible_ssh_user: 'cloud-user',  \
+              ansible_ssh_private_key_file: 'keys/zk_cluster_private_key' }, \
+          '192.168.34.19': { ansible_ssh_host: '192.168.34.19', ansible_ssh_port: 22,  \
+              ansible_ssh_user: 'cloud-user',  \
+              ansible_ssh_private_key_file: 'keys/zk_cluster_private_key' }, \
+          '192.168.34.20': { ansible_ssh_host: '192.168.34.20', ansible_ssh_port: 22,  \
+              ansible_ssh_user: 'cloud-user',  \
+              ansible_ssh_private_key_file: 'keys/zk_cluster_private_key' }, \
+      }, \
+      storm_url: 'http://192.168.34.254/apache-storm/apache-storm-1.0.3.tar.gz', \
+      yum_repo_url: 'http://192.168.34.254/centos', storm_data_dir: '/data' \
+    }" site.yml
+```
+
+Alternatively, rather than passing all of those arguments in on the command-line as extra variables, we can make use of the *local variables file* support that is built into this playbook and construct a YAML file that looks something like this containing the configuration parameters that are being used for this deployment:
+
+```yaml
+cloud: vagrant
+data_iface: eth0
+api_iface: eth1
+zookeeper_nodes:
+    - '192.168.34.18'
+    - '192.168.34.19'
+    - '192.168.34.20'
+zookeeper_inventory:
+    '192.168.34.18':
+        ansible_ssh_host: '192.168.34.18'
+        ansible_ssh_port: 22
+        ansible_ssh_user: 'cloud-user'
+        ansible_ssh_private_key_file: 'keys/zk_cluster_private_key'
+    '192.168.34.19':
+        ansible_ssh_host: '192.168.34.19'
+        ansible_ssh_port: 22
+        ansible_ssh_user: 'cloud-user'
+        ansible_ssh_private_key_file: 'keys/zk_cluster_private_key'
+    '192.168.34.20':
+        ansible_ssh_host: '192.168.34.20'
+        ansible_ssh_port: 22
+        ansible_ssh_user: 'cloud-user'
+        ansible_ssh_private_key_file: 'keys/zk_cluster_private_key'
+storm_url: 'http://192.168.34.254/apache-storm/apache-storm-1.0.3.tar.gz'
+yum_repo_url: 'http://192.168.34.254/centos'
+storm_data_dir: '/data'
+```
+
+and then we can pass in the *local variables file* as an argument to the `ansible-playbook` command; assuming the YAML file shown above was in the current working directory and was named `test-cluster-deployment-params.yml`, the resulting command would look somethin like this:
+
+```bash
+$ ansible-playbook -i test-cluster-inventory -e "{ \
+      host_inventory: ['192.168.34.48', '192.168.34.49', '192.168.34.50'], \
+      local_vars_file: 'test-cluster-deployment-params.yml' \
+    }" site.yml
+```
+
+Once the playbook run is complete, we can simply browse to the Storm UI on one of the nodes in our cluster (eg. http://192.168.34.49:9797) to test and make sure that our Storm cluster is up and running. Do keep in mind that it does take some time for the Storm UI to start after the playbook run completes, so be patient).
+
+## Scenario #3: deploying a Storm cluster via dynamic inventory
+In this section we will repeat the multi-node cluster deployment that we just showed in the previous scenario, but we will use the dynamic inventory scripts provided in the [common-utils](../common-utils) submodule to control the deployment of our Storm cluster to an AWS or OpenStack environment rather than relying on a static inventory file.
+
+To accomplish this, the we have to:
+
+* Tag the instances in the AWS or OpenStack environment that we will be configuring as a Storm cluster with the appropriate `Tenant`, `Project`, `Domain`, and `Application` tags. Note that for all of the nodes we are targeting in our playbook runs, we will assign an `Application` tag of `storm`
+* Have already deployed a Zookeeper ensemble into this environment; this ensemble should be tagged with the same  `Tenant`, `Project`, `Domain` tags that were used when tagging the instances that will make up our Storm cluster (above); obviously the  `Application` for the Zookeeper ensemble nodes would be `zookeeper`
+* Once all of the nodes that will make up our cluster had been tagged appropriately, we can run `ansible-playbook` command similar to the `ansible-playbook` command shown in the previous scenario; this will deploy Storm to the cluster nodes and configure them to talk to the each other through the associated Zookeeper ensemble
+
+In terms of what the commands look like, lets assume for this example that we've tagged our seed nodes with the following VM tags:
+
+* **Tenant**: labs
+* **Project**: projectx
+* **Domain**: preprod
+* **Application**: storm
+
+The `ansible-playbook` command used to deploy Storm to our nodes and configure them as a cluster in an OpenStack environment would then look something like this:
+
+```bash
+$ ansible-playbook -i common-utils/inventory/osp/openstack -e "{ \
+        host_inventory: 'meta-Application_storm:&meta-Cloud_osp:&meta-Tenant_labs:&meta-Project_projectx:&meta-Domain_preprod', \
+        application: storm, cloud: osp, tenant: labs, project: projectx, domain: preprod, \
+        ansible_user: cloud-user, private_key_path: './keys', data_iface: eth0, api_iface: eth1, \
+        storm_data_dir: '/data' \
+    }" site.yml
+```
+
+The playbook uses the tags in this playbook run to identify the nodes that make up the associated Zookeeper ensemble (which must be up and running for this playbook command to work) and the target nodes for the playbook run, installs the Apache Storm distribution on the target nodes, and configures them as a new Storm cluster. 
+
+In an AWS environment, the command would look something like this:
+
+```bash
+$ ansible-playbook -i common-utils/inventory/aws/ec2 -e "{ \
+        host_inventory: 'tag_Application_storm:&tag_Cloud_aws:&tag_Tenant_labs:&tag_Project_projectx:&tag_Domain_preprod', \
+        application: storm, cloud: aws, tenant: labs, project: projectx, domain: preprod, \
+        ansible_user: cloud-user, private_key_path: './keys', data_iface: eth0, api_iface: eth1, \
+        storm_data_dir: '/data' \
+    }" site.yml
+```
+
+As you can see, this command is basically the same command that was shown for the OpenStack use case; it only differs slightly in terms of the name of the inventory script passed in using the `-i, --inventory-file` command-line argument, the value passed in for `Cloud` tag (and the value for the associated `cloud` variable), and the prefix used when specifying the tags that should be matched in the `host_inventory` value (`tag_` instead of `meta-`). In both cases the result would be a set of nodes deployed as a Storm cluster, with the number of nodes in the cluster determined (completely) by the tags that were assigned to the VMs in the cloud environment in question.

--- a/docs/Deployment-via-Vagrant.md
+++ b/docs/Deployment-via-Vagrant.md
@@ -1,0 +1,76 @@
+# Deployment via Vagrant
+A [Vagrantfile](../Vagrantfile) is included in this repository that can be used to deploy Storm locally (to one or more VMs hosted under [VirtualBox](https://www.virtualbox.org/)) using [Vagrant](https://www.vagrantup.com/).  From the top-level directory of this repository a command like the following will (by default) deploy Storm to a single CentOS 7 virtual machine running under VirtualBox:
+
+```bash
+$ vagrant -s="192.168.34.42" up
+```
+
+Note that the `-s, --storm-list` flag must be used to pass an IP address (or a comma-separated list of IP addresses) into the [Vagrantfile](../Vagrantfile). In the example shown above, we are performing a single-node deployment of Storm, so an instance of Zookeeper will also be started on that same node during the deployment process and the Storm instance will be configured to talk to that Zookeeper instance .
+
+When we are performing a multi-node deployment, then the nodes that make up the existing zookeeper ensemble must also be defined as part of the `vagrant ... up` command, as in this example:
+
+```bash
+$ vagrant -s="192.168.34.48,192.168.34.49,192.168.34.50" \
+    -z="192.168.34.18,192.168.34.19,192.168.34.20" \
+    -i='./zookeeper_inventory' up
+```
+
+This command will create a three-node Storm cluster, configuring those nodes to work with the associated Zookeeper ensemble (which has been passed in using the `-z, --zookeeper-list` flag). Note that a third argument (the `-i, --zk-inventory-file` command-line argument) must also be included in this command. That argument is used to pass in a reference to the location of a static inventory file containing the information needed to connect to the nodes in the Zookeeper ensemble (so that the playbook can gather facts about those nodes to configure the Storm nodes to talk to them correctly). If either of these two arguments are not provided when building a multi-node cluster, or if the values passed in by either of them are not valid values, then an error will be thrown by the `vagrant` command.
+
+In terms of how it all works, the [Vagrantfile](../Vagrantfile) is written in such a way that the following sequence of events occurs when the `vagrant ... up` command shown above is run:
+
+1. All of the virtual machines in the cluster (the addresses in the `-s, --storm-list`) are created
+1. After all of the nodes have been created, Storm is deployed all of those nodes and they are all configured as a cluster in a single Ansible playbook run
+1. The `storm` service is started on all of the nodes that were just provisioned
+
+Once the playbook run triggered by the [Vagrantfile](../Vagrantfile) is complete, we can simply browse to the Storm UI on one of the nodes in our cluster (eg. http://192.168.34.49:9797) to test and make sure that our Storm cluster is up and running. Do keep in mind that it does take some time for the Storm UI to start after the playbook run completes, so be patient.
+
+So, to recap, by using a single `vagrant ... up` command we were able to quickly spin up a cluster consisting of of three Storm nodes and configure those nodes as a cluster that is associated with an existing Zookeeper ensemble. A similar `vagrant ... up` command could be used to build a cluster consisting of any number of Storm nodes, provided that a Zookeeper ensemble has already been provisioned that can be associated with the nodes in that cluster.
+
+## Separating instance creation from provisioning
+While the `vagrant up` commands that are shown above can be used to easily deploy Storm to a single node or to build a Storm cluster consisting of multiple nodes, the [Vagrantfile](../Vagrantfile) included in this distribution also supports separating out the creation of the virtual machine from the provisioning of that virtual machine using the Ansible playbook contained in this repository's [site.yml](../site.yml) file.
+
+To create a set of virtual machines that we plan on using to build a Storm cluster without provisioning Storm to those machines, simply run a command similar to the following:
+
+```bash
+$ vagrant -s="192.168.34.48,192.168.34.49,192.168.34.50" \
+    up --no-provision
+```
+
+This will create a set of three virtual machines with the appropriate IP addresses ("192.168.34.48", "192.168.34.49", and "192.168.34.50"), but will skip the process of provisioning those VMs with an instance of Storm. Note that when you are creating the virtual machines but skipping the provisioning step it is not necessary to provide the list of zookeeper nodes using the `-z, --zookeeper-list` flag, nor is it necessary to provide an inventory file for those zookeeper nodes using the `-i, --zk-inventory-file` flag.
+
+To provision the machines that were created above and configure those machines as a Storm cluster, we simply need to run a command like the following:
+
+```bash
+$ vagrant -s="192.168.34.48,192.168.34.49,192.168.34.50" \
+    -z="192.168.34.18,192.168.34.19,192.168.34.20" \
+    -i='./zookeeper_inventory' provision
+```
+
+That command will attach to the named instances and run the playbook in this repository's [site.yml](../site.yml) file on those node, resulting in a Storm cluster consisting of the nodes that were created in the `vagrant ... up --no-provision` command that was shown, above.
+
+## Additional vagrant deployment options
+While the commands shown above will install Storm with a reasonable, default configuration from a standard location, there are additional command-line parameters that can be used to control the deployment process triggered by a `vagrant ... up` or `vagrant ... provision` command. Here is a complete list of the command-line flags that can be supported by the [Vagrantfile](../Vagrantfile) in this repository:
+
+* **`-s, --storm-list`**: the Storm address list; this is the list of nodes that will be created and provisioned, either by a single `vagrant ... up` command or by a `vagrant ... up --no-provision` command followed by a `vagrant ... provision` command; this command-line flag **must** be provided for almost every `vagrant` command supported by the [Vagrantfile](../Vagrantfile) in this repository
+* **`-z, --zookeeper-list`**: a comma-separated list of the nodes that make up the associated Zookeeper ensemble; this argument **must** be provided for any `vagrant` commands that involve provisioning of the instances that make up a Storm cluster
+* **`-i, --zk-inventory-file`**: the path to a static inventory file containing the parameters needed to connect to the nodes that make up the associated Zookeeper ensemble; this argument **must** be provided for any `vagrant` commands that involve provisioning of the instances that make up a Storm cluster
+* **`-p, --path`**: the path that the distribution should be unpacked into; defaults to `/opt/apache-storm` 
+* **`-u, --url`**: the URL that the Apache Storm distribution should be downloaded from; can be used to override the default URL used to to download the gzipped tarfile containing the Apache Storm distribution for situations with limited (or no) internet access
+* **`-l, --local-path`**: the local directory (on the Ansible host) containing the Apache Storm (and Apache Zookeeper) distributions; when used, the distribution file (or files in a single-node deployment) will be uploaded to the target nodes from this directory, then unpacked into the installation directory. If this parameter and the `-u, --url` parameter are both defined and error will be thrown
+* **`-d, --data`**: the path to the directory where Storm will store it's data; this defaults to `/var/lib` if not specified
+* **`-y, --yum-url`**: the local YUM repository URL that should be used when installing packages during the node provisioning process. This can be useful when installing Storm onto CentOS-based VMs in situations where there is limited (or no) internet access; in this situation the user might want to install packages from a local YUM repository instead of the standard CentOS mirrors. It should be noted here that this parameter is not used when installing Storm on RHEL-based VMs; in such VMs this option will be silently ignored if set
+* **`-f, --local-vars-file`**: the *local variables file* that should be used when deploying the cluster. A local variables file can be used to maintain the configuration parameter definitions that should be used for a given Storm cluster deployment, and values in this file will override any values that are either embedded in the [vars/storm.yml](../vars/storm.yml) file as defaults or passed into the `ansible-playbook` command as extra variables
+* **`-c, --clear-proxy-settings`**: if set, this command-line flag will cause the playbook to clear any proxy settings that may have been set on the machines being provisioned in a previous ansible-playbook run. This is useful for situations where an HTTP proxy might have been set incorrectly and, in a subsequent playbook run, we need to clear those settings before attempting to install any packages or download the Storm distribution without an HTTP proxy
+
+As an example of how these options might be used, the following command will download the gzipped tarfile containing the Apache Storm distribution from a local web server, configure Storm to store it's data in the `/data` directory, and install packages from the CentOS mirror on the web server at `http://192.168.34.254/centos` when provisioning the machines created by the `vagrant ... up --no-provision` command shown above:
+
+```bash
+$ vagrant -s="192.168.34.48,192.168.34.49,192.168.34.50" \
+    -z="192.168.34.18,192.168.34.19,192.168.34.20" \
+    -i='/Users/tjmcs/Vagrant/dn-zookeeper/.vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory' \
+    -d="/data" -u='http://192.168.34.254/apache-storm/apache-storm-1.0.3.tar.gz' \
+    -y='http://192.168.34.254/centos' provision
+```
+
+While the list of command-line options defined above may not cover all of the customizations that user might want to make when performing production Storm deployments, our hope is that the list shown above is more than sufficient for deploying Storm clusters using Vagrant for local testing purposes.

--- a/docs/Dynamic-vs-Static-Inventory.md
+++ b/docs/Dynamic-vs-Static-Inventory.md
@@ -1,0 +1,49 @@
+# Dynamic vs. static inventory
+The first decision to make is when using the playbook in this repository to deploy Storm is whether you would like to manage the inventory for your deployments using the dynamic inventory scripts that are provided in the [common-utils](../common-utils) submodule for AWS and OpenStack environments or whether you are managing your inventory statically. Since the static inventory use case is the simplest, we'll start our discussion there. Then we'll move on to a discussion of how to control the deployment of Storm in both AWS and OpenStack environments by tagging the VMs in those environments so that the dynamic inventory scripts from the [common-utils](../common-utils) submodule can be used to dynamically construct the lists of nodes that should be targeted by a given `ansible-playbook` run.
+
+## Managing deployments with static inventory files
+Let's assume that we are planning the deployment of a three-node Storm cluster using the playbook in this repository and we are planning on using a [static inventory file](https://docs.ansible.com/ansible/intro_inventory.html) to control that deployment. In this example (and others like it in this document) we'll assume that we're going to construct a single static inventory file (an INI-like formatted file containing the list of hosts that are targeted by any given playbook run), and then pass that file into the `ansible-playbook` command using the `-i, --inventory-file` command-line flag.
+
+In our discussion of the various deployment scenarios supported by this playbook, we show that deployments of a Storm cluster actually require an associated (assumed to be external) Zookeeper ensemble. For purposes of this discussion, we will focus only on the inventory information associated with the Storm nodes, not on the inventory information associated with the Zookeeper ensemble. So, returning to our example, the inventory file associated with our three-node Storm cluster might look something like this:
+
+```bash
+$ cat test-cluster-inventory
+# example inventory file for a clustered deployment
+
+192.168.34.48 ansible_ssh_host= 192.168.34.48 ansible_ssh_port=22 ansible_ssh_user='cloud-user' ansible_ssh_private_key_file='keys/storm_cluster_private_key'
+192.168.34.49 ansible_ssh_host= 192.168.34.49 ansible_ssh_port=22 ansible_ssh_user='cloud-user' ansible_ssh_private_key_file='keys/storm_cluster_private_key'
+192.168.34.50 ansible_ssh_host= 192.168.34.50 ansible_ssh_port=22 ansible_ssh_user='cloud-user' ansible_ssh_private_key_file='keys/storm_cluster_private_key'
+
+$
+```
+As you can see, our static inventory file consists of a list of the hosts that make up the inventory for our deployment. For each host in this file, we provide a list of the parameters that Ansible will need to connect to that host (INI-file style) as a set of `name=value` pairs. In this example, we've defined the following values for each of the entries in our static inventory file:
+
+* **`ansible_ssh_host`**: the hostname/address that Ansible should use to connect to that host; if not specified, the same hostname/address listed at the start of the line for that entry for that host will be used (in this example we are using IP addresses). This parameter can be important when there are multiple network interfaces on each host and only one of them (an admin network, for example) allows for SSH access
+* **`ansible_ssh_port`**: the port that Ansible should use when connecting to the host via SSH; if not specified, Ansible will attempt to connect using the default SSH port (port 22)
+* **`ansible_ssh_user`**: the username that Ansible should use when connecting to the host via SSH; if not specified, then the value of the global `ansible_user` variable will be used (this variable can be set as an extra variable in the `ansible-playbook` command if the same username is used for all hosts targeted by the playbook run)
+* **`ansible_ssh_private_key_file`**: the private key file that should be used when connecting to the host via SSH; if not specified, then the value of the global `ansible_ssh_private_key_file` variable will be used instead (this variable can be set as an extra variable in the `ansible-playbook` command if the same private key is used for all hosts targeted by the playbook run)
+
+With this static inventory file built, it's a relatively simple matter to deploy our Storm cluster using a single `ansible-playbook` command. Examples of these commands are shown [here](Deployment-Scenarios.md).
+
+## Managing deployments using dynamic inventory scripts
+For both AWS and OpenStack environments, the playbook in this repository supports the use of a [dynamic inventory](https://docs.ansible.com/ansible/intro_dynamic_inventory.html) to control deployments to those environments. This is accomplished by making use of the [build-app-host-groups](../common-roles/build-app-host-groups) common role, which in turn uses the dynamic inventory scripts that are included for these two types of environments in the [common-utils](../common-utils) submodule. These scripts return lists of the nodes that should be targeted by a given playbook run, and the [build-app-host-groups](../common-roles/build-app-host-groups) common role filters those lists, based on the tags that are assigned them and the tags that are included in the `ansible-playbook` command, to construct the host groups needed for a given deployment. This provides an attractive alternative to building static inventory files to control the deployment process in these environments, since the meta-data needed to determine which nodes should be targeted by a given playbook run is readily available in the framework itself.
+
+The process of using the [build-app-host-groups](../common-roles/build-app-host-groups) common role to control a playbook run starts out by tagging the VMs that are going to be the target of a particular deployment with the following tags:
+
+* **Tenant**: the tenant that will be using the Storm cluster being deployed. As an example, you might use a value of `labs` for this tag for Storm clusters that the Labs department in your organization will be using)
+* **Project**: this tag will be given the value of the project that will be using the Storm cluster that is being deployed; for example we might use the value `projectx` for this tag for clusters that will be used for ProjectX
+* **Domain**: this tag is used to separate out the various domains that might be defined by the project team to control their deployments. For example, there might be separate clusters built for `development`, `test`, `preprod`, and `production`. Each of these environments would be tagged appropriately based on their intended use.
+* **Application**: this tag is used to identify the application that should be deployed to a given virtual machine; in this playbook only nodes that are tagged with the application `storm` are targeted by default (and although the application name is something you could customize, we recommend against doing so)
+
+It should be noted here that this playbook assumes that an associated Zookeeper ensemble has already been deployed that can be associated with the Storm cluster that the playbook run is deploying. In the dynamic inventory use case, the nodes that make up this Zookeeper ensemble must be tagged with the same `Tenant`, `Project`, and `Domain` tag values that are used to build the associated Storm cluster. Obviously, these Zookeeper instances would have been tagged with an `Application` tag of `zookeeper`, but if the remaining tags do not match then the playbook will not be able to find the associated Zookeeper ensemble and the Storm cluster nodes will fail to start.
+
+Once these tags have been assigned to the VMs that will be targeted by a given Storm deployment, it is a relatively simple process to define values for the tags that should be targeted by the `ansible-playbook` command (as extra variables or in a *local variables file*, for example). Specifically, the following variables must be defined when using this dynamic inventory to manage a playbook run:
+
+* **tenant**
+* **project**
+* **domain**
+* **application**
+
+Note that the `application` value defaults to `storm` (the default value defined at the top of the [vars/storm.yml](../vars/storm.yml) file), so this value does not really need to be redefined as part of the `ansible-playbook` command or in a or in a *local variables file*, but it is shown here for completeness.
+
+With these values assigned as part of the `ansible-playbook` command or in a or in a *local variables file*, the [build-app-host-groups](../common-roles/build-app-host-groups) role that is used by this playbook can correctly identify the nodes in the AWS or OpenStack environment that are targeted by a given playbook run and then use the resulting (dynamically constructed) lists of Storm and Zookeeper nodes to control the deployment of Storm to the nodes that will make up the cluster being built.

--- a/docs/Supported-Config-Params.md
+++ b/docs/Supported-Config-Params.md
@@ -1,0 +1,68 @@
+# Supported configuration parameters
+The playbook in the [site.yml](../site.yml) file in this repository pulls in a set of default values for many of the configuration parameters that are needed to deploy Storm from the [vars/storm.yml](../vars/storm.yml) file. The parameters defined in that file define a reasonable set of defaults for a fairly generic Storm deployment, either to a single node or a cluster, including defaults for the URL that the Storm distribution should be downloaded from, the directory that the Storm nodes should store their data in, and the packages that must be installed on the node before the `storm` service can be started.
+
+In addition to the defaults defined in the [vars/storm.yml](../vars/storm.yml) file, there are a larger set of parameters that can be used to either control the deployment of Storm to the nodes that will make up a cluster during an `ansible-playbook` run or to configure those Storm nodes once the installation is complete. In this section, we summarize these options, breaking them out into:
+
+* parameters used to control the `ansible-playbook` run
+* parameters used during the deployment process itself, and
+* parameters used to configure our Storm nodes once Storm has been installed locally.
+
+Each of these sets of parameters are described in their own section, below.
+
+## Parameters used to control the playbook run
+The following parameters can be used to control the `ansible-playbook` run itself, defining things like how Ansible should connect to the nodes involved in the playbook run, which nodes should be targeted, where the Storm distribution should be downloaded from, which packages must be installed during the deployment process, and where those packages should be obtained from:
+
+* **`ansible_ssh_private_key_file`**: the location of the private key that should be used when connecting to the target nodes via SSH; this parameter is useful when there is one private key that is used to connect to all of the target nodes in a given playbook run
+* **`ansible_user`**: the username that should be used when connecting to the target nodes via SSH; is useful if the same username is used when connecting to all of the target nodes in a given playbook run
+* **`storm_url`**: the URL that the Apache Storm distribution should be downloaded from
+* **`storm_version`**: the version of Storm that should be downloaded; used to switch versions when the distribution is downloaded using the default `storm_url`, which is defined in the [vars/storm.yml](../vars/storm.yml) file
+* **`zookeeper_url`**: the URL that the Apache Zookeeper distribution should be downloaded from for single-node Storm deployments
+* **`zookeeper_version`**: the version of Zookeeper that should be downloaded for single-node Storm deployments; used to switch versions when the distribution is downloaded using the default `zookeeper_url`, which is defined in the [vars/storm.yml](../vars/storm.yml) file
+* **`cloud`**: the name of the cloud type being targeted (`aws`, `osp`, or `vagrant`); this controls whether the inventory information for the playbook run is assumed to be passed in dynamically (when the cloud is `aws` or `osp`) or statically (if the cloud type is `vagrant`)
+* **`host_inventory`**: used to pass in a list of the nodes targeted for deployment (in the static inventory use case) or a union of the application, tenant, project, and domain tags (in the dynamic inventory use case)
+* **`local_path`**: used to pass in the local path (on the Ansible host) to a directory containing the Storm distribution file; the distribution file will be uploaded from this directory to the target hosts and unpacked into the `storm_dir` directory (note that in the case of a single-node deployment, the Zookeeper distribution file will also be uploaded from this directory and unpacked into the associated `zookeeper_dir` directory). The filename that will be uploaded will be the basename of the defined `storm_url` (and the corresponding basename of the `zookeeper_url` for single-node deployments)
+* **`private_key_path`**: used to define the directory where the private keys are maintained when the inventory for the playbook run is being managed dynamically; in these cases, the scripts used to retrieve the dynamic inventory information will return the names of the keys that should be used to access each node, and the playbook will search the directory specified by this parameter to find the corresponding key files. If this value is not specified then the current working directory will be searched for those keys by default
+* **`proxy_env`**: a hash map that is used to define the proxy settings to use for downloading distribution files and installing packages; supports the `http_proxy`, `no_proxy`, `proxy_username`, and `proxy_password` fields as part of this hash map
+* **`reset_proxy_settings`**: used to reset any HTTP/YUM proxy settings that may have been made in a previous playbook run back to the defaults (no proxy); this is useful when a proxy was incorrectly set in a previous playbook run and the user wants to return to a "no-proxy" setup in the current playbook run
+* **`yum_repo_url`**: used to set the URL for a local YUM mirror. This parameter is only used for CentOS-based deployments; when deploying Storm to RHEL-based nodes this parameter is silently ignored and the RHEL package repositories defined locally on the node will be used for any packages installed during the deployment process
+
+## Parameters used during the deployment process
+These parameters are used to control the deployment process itself, defining things like where the distribution should be unpacked, the user/group that should be used when unpacking the distribution and starting the `storm` service, and which packages to install.
+
+* **`storm_dir`**: the path to the directory that the Storm distribution should be unpacked into; defaults to `/opt/apache-storm` if unspecified
+* **`zookeeper_dir`**: the path to the directory that the Zookeeper distribution should be unpacked into for single-node deployments; defaults to `/opt/apache-zookeeper` if unspecified
+* **`storm_package_list`**: the list of packages that should be installed on the Storm nodes; typically this parameter is left unchanged from the default (which installs the OpenJDK packages needed to run Storm), but if it is modified the default, OpenJDK packages must be included as part of this list or an error will result when attempting to start the `storm` service
+* **`storm_user`**: the username under which Storm should be installed and run; defaults to `storm`
+* **`storm_group`**: the name of the user group under which Storm should be installed and run; defaults to `storm`
+
+## Parameters used to configure the Storm nodes
+These parameters are used configure the Storm nodes themselves during a playbook run, defining things like the interfaces that Storm should be listening on for requests and the directory where Storm should store its data.
+
+* **`storm_iface`**: the name of the interface that the Storm nodes in the cluster should use when talking with each other, when talking to the Zookeeper ensemble, and for user requests. An interface of this name must exist for the playbook to run successfully, and if unspecified a value of `eth0` is assumed
+* **`iface_description_array`**: this parameter can be used in place of the `storm_iface ` parameter described above, and it provides users with the ability to specify a description of that interface rather than identifying it by name (more on this, below)
+* **`storm_data_dir`**: the name of the directory that Storm should use to store its data; defaults to `/var/lib` if unspecified. If necessary, this directory will be created as part of the playbook run
+* **`nimbus_childopts`**: used to set the JVM options for the master; defaults to `-Xmx1024m` if unspecified
+* **`ui_port`**: used to set the `ui.port` property for the master node; defaults to `9797` if unspecified
+* **`ui_childopts`**: used to set the `ui.childopts` property for the master node; defaults to `-Xmx768m` if unspecified
+* **`worker_childopts`**: used to set the JVM options for the task workers; defaults to `-Xmx768m` if unspecified
+
+## Interface names vs. interface descriptions
+For some operating systems on some platforms, it can be difficult (if not impossible) to determine the name of the interface that should be passed into the playbook using the `storm_iface` parameter that we described, above. In those situations, the playbook in this repository provides an alternative; specifying that interface using the `iface_description_array` parameter instead.
+
+Put quite simply, the `iface_description_array` lets you specify a description for each of the networks that you are interested in, then retrieve the names of those networks on each machine in a variable that can be used elsewhere in the playbook. To accomplish this, the `iface_description_array` is defined as an array of hashes (one per interface), each of which include the following fields:
+
+* **`type`**: the type of description being provided, currently only the `cidr` type is supported
+* **`val`**: a value describing the network in question; since only `cidr` descriptions are currently supported, a CIDR value that looks something like `192.168.34.0/24` should be used for this field
+* **`as_var`**: the name of the variable that you would like the interface name returned as
+
+With these values in hand, the playbook will search the available networks on each machine and return a list of the interface names for each network that was described in the `iface_description_array` as the value of the fact named in the `as_var` field for that network's entry. For example, given this description:
+
+```json
+    iface_description_array: [
+        { as_var: 'storm_iface', type: 'cidr', val: '192.168.34.0/24' },
+    ]
+```
+
+the playbook will return the name of the network that matches the CIDR `192.168.34.0/24` as the value of the `storm_iface` fact. This fact can then be used later in the playbook to correctly configure the nodes to talk to each other and listen on the proper interface for user requests.
+
+It should be noted that if you choose to take this approach when constructing your `ansible-playbook` runs, a matching entry in the `iface_description_array` must be specified for the `storm_iface` network, otherwise the default value of `eth0` will be used for this fact (and the playbook run may result in nodes that are at best misconfigured; if the `eth0` network does not exist then the playbook will fail to run altogether).

--- a/site.yml
+++ b/site.yml
@@ -1,10 +1,17 @@
 # (c) 2017 DataNexus Inc.  All Rights Reserved
 ---
-# First, build our storm and zookeeper host groups
+# Build our storm and zookeeper host groups
 - name: Create storm and zookeeper host groups
   hosts: "{{host_inventory}}"
   gather_facts: no
   tasks:
+    # load the 'local variables file', if one was defined, to get any variables
+    # we might need from that file when constructing our host groups
+    - name: Load local variables file
+      include_vars:
+        file: "{{local_vars_file}}"
+      when: not (local_vars_file is undefined or local_vars_file is none or local_vars_file | trim == '')
+    # then, build our host groups
     - include_role:
         name: build-app-host-groups
       vars:
@@ -34,9 +41,16 @@
     - vars/storm.yml
   vars:
     - combined_package_list: "{{ (default_packages|default([])) | union(storm_package_list) | union((install_packages_by_tag|default({})).storm|default([])) }}"
-  # First, restart the network (unless the skip_network_restart was set)
-  # and gather some facts about our Storm node(s)
   pre_tasks:
+    # first, load the local variables file (if one was defined); this will initialize
+    # the variables used in our playbook (and override any values in the 'vars/storm.yml'
+    # file with redefined values from the 'local_vars_file', if any)
+    - name: Load local variables file (if defined)
+      include_vars:
+        file: "{{local_vars_file}}"
+      when: not (local_vars_file is undefined or local_vars_file is none or local_vars_file | trim == '')
+    # then, restart the network (unless the skip_network_restart was set)
+    # and gather some facts about our Storm node(s)
     - name: Ensure the network interfaces are up on our Storm node(s)
       service:
         name: network

--- a/tasks/configure-storm-nodes.yml
+++ b/tasks/configure-storm-nodes.yml
@@ -13,7 +13,7 @@
       dest: "{{storm_dir}}/conf/storm.yaml"
       insertafter: "^storm.zookeeper.servers:"
       line: "    - \"{{item}}\""
-    with_items: "{{zk_nodes}}"
+    with_items: "{{zk_nodes | default([])}}"
   become: true
   become_user: "{{storm_user}}"
   when: (zk_nodes | default([])) != []

--- a/vars/storm.yml
+++ b/vars/storm.yml
@@ -7,18 +7,12 @@ application: storm
 storm_version: "1.0.3"
 storm_url: "http://www-us.apache.org/dist/storm/apache-storm-{{storm_version}}/apache-storm-{{storm_version}}.tar.gz"
 storm_dir: "/opt/apache-storm"
-storm_package_list: ["java-1.8.0-openjdk", "java-1.8.0-openjdk-devel", "net-tools"]
-storm_zookeeper_servers: ["localhost"]
-storm_local_dir: "storm-local"
+storm_package_list: ["java-1.8.0-openjdk", "java-1.8.0-openjdk-devel"]
+storm_data_dir: "/var/lib"
 storm_iface: eth0
-nimbus_seeds: ["localhost"]
 zookeeper_version: "3.4.9"
 zookeeper_url: "http://www-us.apache.org/dist/zookeeper/zookeeper-{{zookeeper_version}}/zookeeper-{{zookeeper_version}}.tar.gz"
 zookeeper_dir: "/opt/apache-zookeeper"
-# the directory where the Zookeeper (in-memory) database snapshots will be written
-zookeeper_data_dir: /var/lib
-# the directory where Zookeeper transaction log will be written
-zookeeper_data_log_dir: /var/log
 # the username and group that should be used when installing and running Storm
 storm_user: "storm"
 storm_group: "storm"


### PR DESCRIPTION
The changes in this PR include the following:
* changes to bring the documentation up to date with the latest changes
* cleanup of the defaults defined in the `vars/storm.yml` file
* cleanup of the options in the `Vagrantfile` to bring them in line with the `Vagrantfiles` in our other playbooks
* adding support for a *local variables file* that can be used pass in options from a YAML file (something that can be maintained under version control external to this repository)