### PR TITLE
Changes to support host groups in static inventory

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,17 +23,15 @@ end
 
 # a function that is used to parse Ansible (static) inventory files and
 # return a list of the node addresses contained in the file
-def addr_list_from_inventory_file(inventory_file)
-  first_field_list = []
-  File.open(inventory_file, 'r') do |f|
-    f.each_line do |line|
-      # grab the first field from each line
-      first_field_list << line.gsub(/\s+/, ' ').strip.split(" ")[0]
-    end
-  end
-  # return the entries that look like IP addresses (skipping the rest)
-  # and only return the unique values in the resulting list
-  first_field_list.select { |addr| (addr =~ Resolv::IPv4::Regex) }.uniq
+def addr_list_from_inventory_file(inventory_file, group_name)
+  inventory_str = `./common-utils/inventory/static/hostsfile.py --filename #{inventory_file} --list`
+  inventory_json = JSON.parse(inventory_str)
+  inventory_group = inventory_json[group_name]
+  # if we found a corresponding group in the inventory file, then
+  # return the hosts list in that group
+  return inventory_group['hosts'] if inventory_group
+  # otherwise, return the keys in the 'hostvars' hash map under the '_meta' hash map
+  inventory_json['_meta']['hostvars'].keys
 end
 
 # initialize a few values
@@ -214,7 +212,7 @@ if provisioning_command || ip_required
           exit 1
         else
           # parse the inventory file that was passed in and retrieve the list of host addresses from it
-          zookeeper_addr_array = addr_list_from_inventory_file(options[:inventory_file])
+          zookeeper_addr_array = addr_list_from_inventory_file(options[:inventory_file], 'zookeeper')
           # and check to make sure that an appropriate number of zookeeper addresses were
           # found in the inventory file (the size of the ensemble should be an odd number
           # between three and seven)
@@ -320,7 +318,7 @@ if storm_addr_array.size > 0
               host_inventory: storm_addr_array,
               reset_proxy_settings: options[:reset_proxy_settings],
               zookeeper_inventory_file: options[:inventory_file],
-              cloud: "vagrant"
+              inventory_type: "static"
             }
             # if defined, set the 'extra_vars[:storm_url]' value to the value that was passed in on
             # the command-line (eg. "https://10.0.2.2/apache-storm-1.0.3.tar.gz")

--- a/docs/Dynamic-vs-Static-Inventory.md
+++ b/docs/Dynamic-vs-Static-Inventory.md
@@ -10,9 +10,9 @@ In our discussion of the various deployment scenarios supported by this playbook
 $ cat test-cluster-inventory
 # example inventory file for a clustered deployment
 
-192.168.34.48 ansible_ssh_host= 192.168.34.48 ansible_ssh_port=22 ansible_ssh_user='cloud-user' ansible_ssh_private_key_file='keys/storm_cluster_private_key'
-192.168.34.49 ansible_ssh_host= 192.168.34.49 ansible_ssh_port=22 ansible_ssh_user='cloud-user' ansible_ssh_private_key_file='keys/storm_cluster_private_key'
-192.168.34.50 ansible_ssh_host= 192.168.34.50 ansible_ssh_port=22 ansible_ssh_user='cloud-user' ansible_ssh_private_key_file='keys/storm_cluster_private_key'
+192.168.34.48 ansible_ssh_host=192.168.34.48 ansible_ssh_port=22 ansible_ssh_user='cloud-user' ansible_ssh_private_key_file='keys/storm_cluster_private_key'
+192.168.34.49 ansible_ssh_host=192.168.34.49 ansible_ssh_port=22 ansible_ssh_user='cloud-user' ansible_ssh_private_key_file='keys/storm_cluster_private_key'
+192.168.34.50 ansible_ssh_host=192.168.34.50 ansible_ssh_port=22 ansible_ssh_user='cloud-user' ansible_ssh_private_key_file='keys/storm_cluster_private_key'
 
 $
 ```

--- a/site.yml
+++ b/site.yml
@@ -18,14 +18,14 @@
         host_group_list:
           - name: storm
           - name: zookeeper
-      when: cloud == 'aws' or cloud == 'osp'
+      when: inventory_type == 'dynamic'
     - include_role:
         name: build-app-host-groups
       vars:
         host_group_list:
           - { name: storm, node_list: "{{host_inventory}}" }
           - { name: zookeeper, inventory_file: "{{zookeeper_inventory_file}}" }
-      when: cloud == "vagrant"
+      when: inventory_type == 'static'
 
 # Collect some Zookeeper related facts
 - name: Gather facts from Zookeeper host group (if defined)
@@ -35,7 +35,7 @@
 # and configure our Storm nodes (note that if more than one node is passed in,
 # those nodes will be configured as a single Storm cluster)
 - name: Install/configure Storm server(s)
-  hosts: storm
+  hosts: storm:&storm_nodes
   gather_facts: no
   vars_files:
     - vars/storm.yml
@@ -87,8 +87,8 @@
   # deploy and configure Storm
   roles:
     - role: get-iface-addr
-      iface_name: "{{storm_iface}}"
-      as_fact: "storm_addr"
+      iface_name: "{{data_iface}}"
+      as_fact: "data_addr"
     - role: setup-web-proxy
     - role: add-local-repository
       yum_repository: "{{yum_repo_url}}"

--- a/tasks/configure-storm-nodes.yml
+++ b/tasks/configure-storm-nodes.yml
@@ -1,7 +1,7 @@
 # (c) 2017 DataNexus Inc.  All Rights Reserved
 ---
 - set_fact:
-    strm_nodes: "{{storm_nodes | map('extract', hostvars, [('ansible_' + storm_iface), 'ipv4', 'address']) | list}}"
+    strm_nodes: "{{storm_nodes | map('extract', hostvars, [('ansible_' + data_iface), 'ipv4', 'address']) | list}}"
 - block:
   - name: Configure storm to use ane external zookeeper cluster (if defined)
     lineinfile:
@@ -57,12 +57,12 @@
     lineinfile:
       dest: "{{storm_dir}}/conf/storm.yaml"
       regexp: "^(.*)storm.local.hostname:"
-      line: "storm.local.hostname: {{storm_addr}}"
+      line: "storm.local.hostname: {{data_addr}}"
   - name: Set UI host for storm node(s)
     lineinfile:
       dest: "{{storm_dir}}/conf/storm.yaml"
       regexp: "^(.*)ui.host:"
-      line: "ui.host: {{storm_addr}}"
+      line: "ui.host: {{data_addr}}"
   - name: Setup UI options for storm node(s)
     lineinfile:
       dest: "{{storm_dir}}/conf/storm.yaml"

--- a/vars/storm.yml
+++ b/vars/storm.yml
@@ -9,7 +9,7 @@ storm_url: "http://www-us.apache.org/dist/storm/apache-storm-{{storm_version}}/a
 storm_dir: "/opt/apache-storm"
 storm_package_list: ["java-1.8.0-openjdk", "java-1.8.0-openjdk-devel"]
 storm_data_dir: "/var/lib"
-storm_iface: eth0
+data_iface: eth0
 zookeeper_version: "3.4.9"
 zookeeper_url: "http://www-us.apache.org/dist/zookeeper/zookeeper-{{zookeeper_version}}/zookeeper-{{zookeeper_version}}.tar.gz"
 zookeeper_dir: "/opt/apache-zookeeper"


### PR DESCRIPTION
The changes in this pull request update the `Vagrantfile`, `common-roles` submodule version, documentation, and playbook in this repository to:

* Support the use of a combined inventory file (where both the Storm nodes that make up a Storm cluster and the Zookeeper ensemble that those nodes are being integrated with are in a single static inventory file)
    * as part of this change, we have added a _filter_ to the hosts targeted by the deployment play (based on the `storm_nodes` host group) so that only nodes in the input `host_inventory` will be targeted by the playbook run, regardless of how many nodes may be in the `storm` host group in the inventory file that is passed in
* Support the `inventory_type` parameter that was recently added to the `common-roles` submodule
    * this parameter is now used to define whether the inventory in the playbook being managed statically (if the value is `static`) or dynamically (if the value is `dynamic`)
    * the `cloud` parameter that was previously used for this purpose and to describe how the inventory should be retreived/parsed in the dynamic inventory use case is now only used if the `inventory_type` is set to `dynamic` (in which case it can be either an `aws` or an `osp` cloud type).
* modified playbook to use `data_iface` extra variable instead of `zookeeper_iface` (and to use the `data_addr` fact instead of the `zookeeper_addr` fact); this brings the name of this parameter inline with the other playbooks we've written, making it easier for users of multiple-playbooks to guess which parameters they should set in their `ansible-playbook` runs.

In addition, we have updated the documentation in this repository to reflect these changes. With these changes we should now be able to use a single, static inventory file (with appropriate host groups defined for the `storm` and `zookeeper` host groups in that static inventory file) to control the deployment of a Storm cluster and integration of that cluster with a pre-existing Zookeeper ensemble.